### PR TITLE
remove light mode theme

### DIFF
--- a/app/app-layout.tsx
+++ b/app/app-layout.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link'
 import { DevBreakpointIndicator } from '@/components/dev-utils/dev-breakpoint-indicator'
 import { SnapshotStatusIndicator } from '@/components/snapshot-status-indicator'
 import { Button } from '@/components/ui/button'
-import { ThemeButton } from '@/components/ui/theme-button'
 
 import { AppNav } from './app-nav'
 
@@ -19,7 +18,6 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
 
         <div className="flex items-center justify-end gap-3">
           <SnapshotStatusIndicator />
-          <ThemeButton />
         </div>
       </header>
       {children}

--- a/app/app-nav.tsx
+++ b/app/app-nav.tsx
@@ -12,9 +12,7 @@ function NavLink({ href, children }: { href: string; children: React.ReactNode }
   return (
     <Button
       variant="ghost"
-      className={cn(
-        isActive ? 'bg-accent text-accent-foreground dark:bg-accent/50' : 'text-muted-foreground',
-      )}
+      className={cn(isActive ? 'bg-accent/50 text-accent-foreground' : 'text-muted-foreground')}
       asChild
     >
       <Link href={href}>{children}</Link>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,6 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 
-@custom-variant dark (&:is(.dark *));
-
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -48,7 +46,6 @@
   --color-info: var(--color-blue-500);
 }
 
-/* shadcn/ui dark mode theme only */
 :root {
   --radius: 0.45rem;
   --background: oklch(0.145 0 0);

--- a/app/globals.css
+++ b/app/globals.css
@@ -48,43 +48,9 @@
   --color-info: var(--color-blue-500);
 }
 
+/* shadcn/ui dark mode theme only */
 :root {
   --radius: 0.45rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --foreground-dim: oklch(0.48 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.7 0 0);
-  --input: oklch(0.7 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(73.2% 0.155 239.96);
-  --chart-2: oklch(81.1% 0.138 164.4);
-  --chart-3: oklch(69.5% 0.2 38.47);
-  --chart-4: oklch(76.5% 0.204 328.58);
-  --chart-5: oklch(84.6% 0.156 83.26);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
-}
-
-.dark {
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,6 @@ import './globals.css'
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 
-import { ThemeProvider } from '@/app/theme-provider'
 import { Analytics } from '@vercel/analytics/next'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import { NuqsAdapter } from 'nuqs/adapters/next/app'
@@ -36,14 +35,7 @@ export default function RootLayout({
       <body className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased`}>
         <NuqsAdapter>
           <ConvexClientProvider>
-            <ThemeProvider
-              attribute="class"
-              defaultTheme="system"
-              enableSystem
-              disableTransitionOnChange
-            >
-              <AppLayout>{children}</AppLayout>
-            </ThemeProvider>
+            <AppLayout>{children}</AppLayout>
           </ConvexClientProvider>
         </NuqsAdapter>
         <Analytics />

--- a/components/brand-icon/brand-icon.tsx
+++ b/components/brand-icon/brand-icon.tsx
@@ -45,24 +45,13 @@ function getIconSlug(slug: string) {
 
 function LobeIcon({ slug, size, alt = '' }: { slug: string; size: number; alt?: string }) {
   return (
-    <>
-      <Image
-        src={`https://unpkg.com/@lobehub/icons-static-png@latest/dark/${slug}.png`}
-        alt={alt}
-        fill
-        sizes={`${size}px`}
-        style={{ objectFit: 'contain' }}
-        className="hidden dark:block"
-      />
-      <Image
-        src={`https://unpkg.com/@lobehub/icons-static-png@latest/light/${slug}.png`}
-        alt={alt}
-        fill
-        sizes={`${size}px`}
-        style={{ objectFit: 'contain' }}
-        className="block dark:hidden"
-      />
-    </>
+    <Image
+      src={`https://unpkg.com/@lobehub/icons-static-png@latest/dark/${slug}.png`}
+      alt={alt}
+      fill
+      sizes={`${size}px`}
+      style={{ objectFit: 'contain' }}
+    />
   )
 }
 

--- a/components/shared/pill.tsx
+++ b/components/shared/pill.tsx
@@ -14,7 +14,7 @@ export function Pill({
   return (
     <Badge variant="outline" className={cn('rounded-none px-3 py-1', className)}>
       <span className="text-foreground-dim uppercase">{label}</span>
-      <span className="mx-1 h-3 w-px bg-border/95 dark:bg-border" />
+      <span className="mx-1 h-3 w-px bg-border" />
       <span>{children}</span>
     </Badge>
   )


### PR DESCRIPTION
### TL;DR

Simplified CSS theme by removing light mode variables and using only dark mode theme.

### What changed?

- Removed all light mode CSS variables from the `:root` selector
- Moved dark mode variables directly into the `:root` selector
- Removed the `.dark` class selector entirely
- Added a comment to clarify this is "shadcn/ui dark mode theme only"

### How to test?

1. Run the application and verify the UI appearance is consistent with dark mode
2. Check that all components using these theme variables render correctly
3. Verify no visual regressions in the application's appearance

### Why make this change?

This change streamlines the theming approach by standardizing on dark mode only, which simplifies the codebase and removes unused CSS variables. This makes the styling more maintainable and reduces potential confusion about theme implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified navigation link styling and unified active state background appearance.
  * Updated separator styling in the Pill component to use a fully opaque background.
  * Removed custom light theme CSS variables, retaining only dark theme variables.
  * Simplified brand icon to display a single dark-themed icon without theme-based switching.

* **Refactor**
  * Removed theme management components and controls from the layout and header, eliminating theme switching functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->